### PR TITLE
Fork-safe review via workflow_run split (drop pull_request_target)

### DIFF
--- a/.github/workflows/code-review-collect.yml
+++ b/.github/workflows/code-review-collect.yml
@@ -1,0 +1,26 @@
+name: Collect PR coordinates
+
+# Stage 1 of the fork-safe review split. Runs untrusted (on the PR's own code)
+# and therefore holds NO secret. Its only job is to record which PR needs review
+# — the number and head SHA — and hand them to the trusted reviewer (stage 2,
+# code-review.yml) as an artifact. It checks out nothing and runs no PR code.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  collect:
+    name: Record PR coordinates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write coordinates
+        run: |
+          mkdir -p pr
+          echo "${{ github.event.pull_request.number }}" > pr/number
+          echo "${{ github.event.pull_request.head.sha }}" > pr/head_sha
+
+      - name: Upload coordinates
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-coordinates
+          path: pr/

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,59 +1,46 @@
 name: AI Code Review with Z.ai
 
-# Two triggers, split by trust class. The z.ai action reads the changed files
-# from the GitHub API (pulls.listFiles) and posts via the API — it never needs
-# the PR's code on disk. The checkout only gives the review agent surrounding
-# context, and the agent is read-only (Bash/Edit/Write/WebFetch disallowed).
-#
-# So the only workflow-level risk is the generic one: a secret-bearing job
-# touching checked-out fork code. We avoid it by never checking out fork code
-# in a job that holds the secret.
+# Stage 2 of the fork-safe review split. Triggered by the collector (stage 1,
+# code-review-collect.yml) finishing. workflow_run ALWAYS runs the default
+# branch's workflow file with the default branch's secrets — i.e. trusted base
+# context — regardless of whether the PR came from a fork. This job holds the
+# secret but checks out NO PR code: it receives only the PR number and head SHA
+# as plain text, and the z.ai action fetches the diff and posts the review
+# through the GitHub API. Fork code never lands on the secret-bearing runner.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Collect PR coordinates"]
+    types: [completed]
 
 permissions:
   contents: read
-  pull-requests: write
+  actions: read          # read the collector run's artifact
+  pull-requests: write   # post the review
 
 jobs:
-  # Same-repo branches are trusted contributors. Run on the `pull_request`
-  # event and check out the PR head so the agent has full, current context.
-  review-internal:
-    name: Review (internal branch)
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+  review:
+    name: Review
+    # Only review when the collector succeeded — a failed collector means no
+    # trustworthy coordinates, so there is nothing to review.
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout pull request head
-        uses: actions/checkout@v6
+      - name: Download PR coordinates
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          name: pr-coordinates
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read coordinates
+        id: pr
+        run: |
+          echo "number=$(cat number)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(cat head_sha)" >> "$GITHUB_OUTPUT"
 
       - name: Code Review
         uses: brandon-fryslie/zai-coding-agent-review@v1
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
-
-  # Fork PRs are untrusted. `pull_request_target` runs in the base (trusted)
-  # context, so the secret is available and github.event.pull_request is present
-  # (the action requires it). We check out the BASE branch only — fork code is
-  # never written to this secret-bearing runner. The action still reviews the
-  # fork's diff (fetched via API) and posts the review (via API).
-  review-fork:
-    name: Review (fork)
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout base for context (no fork code)
-        uses: actions/checkout@v6
-
-      - name: Code Review
-        uses: brandon-fryslie/zai-coding-agent-review@v1
-        with:
-          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
## What

Replaces the `pull_request_target` trust-split with the canonical `workflow_run` split, now that the action exposes PR coordinates as inputs ([`zai-coding-agent-review` v1.2.0](https://github.com/brandon-fryslie/zai-coding-agent-review/releases/tag/1.2.0)).

| Stage | File | Trigger | Secret? | Checks out PR code? |
|---|---|---|---|---|
| 1 collector | `code-review-collect.yml` | `pull_request` | **no** | no |
| 2 reviewer | `code-review.yml` | `workflow_run` | yes | **no** |

The collector (untrusted) records the PR number + head SHA as an artifact. The reviewer (trusted base context, secret available) downloads them and reviews via the GitHub API. **Fork code never lands on the secret-bearing runner — structurally, not by remembering not to check out head.** Same path for fork and same-repo PRs, so the prior `is-fork` job branching is gone.

## Why this supersedes #9

#9's `pull_request_target` approach was a per-repo workaround for the action being hardwired to the `pull_request` payload. That root cause is now fixed in the action itself (PR_NUMBER/HEAD_SHA inputs), so the consumer can use the clean pattern.

## Note on reviewing this PR

`workflow_run` only fires from the **default branch**, so this introducing PR cannot be reviewed by its own new mechanism — only the collector runs here. The split becomes active for all PRs once merged. Validated with `actionlint` (clean).