### PR TITLE
git: fix git-get-default-branch to use actual repo default branch

### DIFF
--- a/git/git.plugin.zsh
+++ b/git/git.plugin.zsh
@@ -83,7 +83,11 @@ really-really-amend() {
   fi
 
   local default_branch
-  default_branch="$(git-get-default-branch)"
+  # [LAW:no-silent-failure] abort if default branch cannot be determined — an empty default_branch would silently pass the guard below
+  if ! default_branch="$(git-get-default-branch)"; then
+    rad-red "really-really-amend: cannot determine default branch, aborting"
+    return 1
+  fi
 
   if [[ "${branch_name}" == "${default_branch}" ]]; then
     rad-red "ERROR: Do not force push on the default branch (branch: ${default_branch})"

--- a/git/git.plugin.zsh
+++ b/git/git.plugin.zsh
@@ -48,20 +48,19 @@ alias gdst="git diff --stat"
 git-get-default-branch() {
   local candidate
 
-  candidate="$(git config --get init.defaultBranch)"
-  [[ -n "${candidate}" ]]  && { echo "${candidate}"; return }
+  # [LAW:no-silent-failure] fast path: symbolic ref set by 'git remote set-head origin -a'
+  candidate="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')"
+  [[ -n "${candidate}" ]] && { echo "${candidate}"; return }
 
-  candidate="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
-  [[ -n "${candidate}" ]]  && { echo "${candidate}"; return }
+  # [LAW:no-silent-failure] network fallback: ask the remote directly
+  candidate="$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')"
+  [[ -n "${candidate}" ]] && { echo "${candidate}"; return }
 
-  candidate="$(git rev-parse --verify --quiet "main" >/dev/null 2>&1)" && { echo "main"; return }
-  [[ -n "${candidate}" ]]  && { echo "${candidate}"; return }
+  git rev-parse --verify --quiet "main" >/dev/null 2>&1 && { echo "main"; return }
+  git rev-parse --verify --quiet "master" >/dev/null 2>&1 && { echo "master"; return }
 
-  candidate="$(git rev-parse --verify --quiet "master" >/dev/null 2>&1)" && { echo "master"; return }
-  [[ -n "${candidate}" ]]  && { echo "${candidate}"; return }
-
-  # main is the new default
-  return "main"
+  rad-red "git-get-default-branch: cannot determine default branch for this repo"
+  return 1
 }
 
 really-really-amend() {


### PR DESCRIPTION
## Summary
- `init.defaultBranch` is a new-repo template setting, not the current repo's actual default branch — consulting it first means `really-really-amend`'s guard silently passes on repos where the real default is `master` but the global config says `main`
- Fix uses `git symbolic-ref refs/remotes/origin/HEAD` (fast, no network) → `git remote show origin` (network fallback) → local branch existence checks
- Removes the broken `return "main"` fallback: zsh evaluates it arithmetically to exit code 0 with empty stdout, making the fallback a no-op; replaced with a loud failure per `[LAW:no-silent-failure]`

## Test plan
- [ ] In a repo with `init.defaultBranch=main` globally but `master` as actual default: `git-get-default-branch` returns `master`
- [ ] `really-really-amend` on master branch now correctly blocks and prints error
- [ ] `really-really-amend` on a feature branch still works as expected
- [ ] `git-get-default-branch` works in repos that use `main` as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)