### PR TITLE
git: fix gwt-undo-sync to reset saved main worktree path, not cwd

### DIFF
--- a/git/git-worktree.zsh
+++ b/git/git-worktree.zsh
@@ -358,8 +358,8 @@ gwt-undo-sync() {
     sha="${line#*:}"
 
     if [[ "$type" == "main" ]]; then
-      rad-yellow "Restoring main ($(pwd)) to $sha"
-      git reset --hard "$sha"
+      rad-yellow "Restoring main ($path) to $sha"
+      git -C "$path" reset --hard "$sha"
     elif [[ "$type" == "wt" ]]; then
       rad-yellow "Restoring ${path:t} to $sha"
       git -C "$path" reset --hard "$sha"


### PR DESCRIPTION
## Summary
- `gwt-undo-sync` parsed the saved `$path` from the state file but the `main` branch ignored it, running bare `git reset --hard` in whatever directory the user was currently in
- The `wt` branch already used `git -C "$path"` correctly — the fix mirrors that pattern for `main`
- Also fixes the log message to print the saved `$path` instead of the ambient `$(pwd)`

## Trigger scenario
After a failed `gwt-sync-all`, the tool advises the user to `cd` into a conflicted worktree to inspect it. Running `gwt-undo-sync` from there would hard-reset that worktree to the main worktree's old SHA, destroying its commits and working state.

## Test plan
- [ ] Run `gwt-sync-all` from the main worktree, then `cd` into a different worktree and run `gwt-undo-sync` — confirm it resets the main worktree (not the current directory)
- [ ] Confirm the log message now shows the saved path, not `$(pwd)`

Closes brandon-git-plugin-obc.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)