### PR TITLE
docker: fix docker-clean deleting tagged images on all hosts

### DIFF
--- a/docker/bin/docker-clean.rb
+++ b/docker/bin/docker-clean.rb
@@ -29,8 +29,8 @@ def clean_none_images
   images = DockerSupport.get_untagged_images
   puts "Found #{images.length.to_s.yellow} <none> images"
   images.each do |image|
-    DockerSupport.all_hosts do |docker_host|
-      puts "Removing image #{image[:repo]} with tag #{image[:tag]} on #{docker_host}"
+    image[:untagged_hosts].each do |docker_host|
+      puts "Removing image #{image[:repo]} with tag #{image[:tag]} on #{docker_host.empty? ? 'local' : docker_host}"
       DockerSupport.command docker_host, "docker rmi #{image[:sha]}"
     end
   end

--- a/docker/bin/docker-support.rb
+++ b/docker/bin/docker-support.rb
@@ -113,12 +113,24 @@ module DockerSupport
       end
     end.map { |thread| thread.value }.reduce({}) do |accum, host_image_data|
       host_image_data.each do |image|
+        untagged = image[:repo] == '<none>' || image[:tag] == '<none>'
         if accum.has_key?(image[:sha])
-          accum[image[:sha]][:hosts].push(image[:host])
+          if untagged
+            accum[image[:sha]][:untagged_hosts].push(image[:host])
+          else
+            accum[image[:sha]][:tagged_hosts].push(image[:host])
+          end
         else
-          image[:full_name] = "#{image[:repo]}:#{image[:tag]}"
-          accum[image[:sha]] = image
-          accum[image[:sha]][:hosts] = [image[:host]]
+          accum[image[:sha]] = {
+            :sha => image[:sha],
+            :repo => image[:repo],
+            :tag => image[:tag],
+            :full_name => image[:full_name],
+            :size => image[:size],
+            :host => image[:host],
+            :untagged_hosts => untagged ? [image[:host]] : [],
+            :tagged_hosts => untagged ? [] : [image[:host]]
+          }
         end
       end
       accum
@@ -126,7 +138,7 @@ module DockerSupport
   end
 
   def DockerSupport.get_untagged_images
-    DockerSupport.get_docker_image_data.select { |image| image[:repo] == '<none>' || image[:tag] == '<none>' }
+    DockerSupport.get_docker_image_data.select { |image| image[:untagged_hosts].any? }
   end
 
   # Get information about the docker containers on a host


### PR DESCRIPTION
## Summary
- `get_docker_image_data` previously merged all hosts for a given image SHA into one record, taking `:repo`/`:tag` from whichever host enumerated first and losing per-host tagging state
- `clean_none_images` then called `DockerSupport.all_hosts` — deleting by SHA on every host, including hosts where the image is actually tagged
- Fix: track `untagged_hosts` and `tagged_hosts` per image SHA during the merge; `get_untagged_images` selects on `untagged_hosts.any?`; `clean_none_images` iterates `image[:untagged_hosts]` instead of all hosts

## Test plan
- [ ] On a single-host setup, `docker-clean` still removes `<none>` images as before
- [ ] On a multi-host setup where the same SHA is untagged on host A and tagged on host B: `docker rmi` runs only on host A, not host B
- [ ] Images that are tagged on all hosts are not touched

Fixes: brandon-docker-91h.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)