### PR TITLE
docker: fix docker-support dropping first image via spurious tail -n +2

### DIFF
--- a/docker/bin/docker-support.rb
+++ b/docker/bin/docker-support.rb
@@ -91,7 +91,7 @@ module DockerSupport
     format_string = '{{.ID}}\|{{.Repository}}\|{{.Tag}}\|{{.Size}}'
 
     ENV['DOCKER_HOST'] = docker_host
-    `docker images --format #{format_string} | tail -n +2`.lines.map do |line|
+    `docker images --format #{format_string}`.lines.map do |line|
       out = line.split('|')
       {
         :full_name => "#{out[1]}:#{out[2]}",


### PR DESCRIPTION
## Summary
- `docker images --format '{{.ID}}\|...'` (no `table` prefix) emits **no header row** — `tail -n +2` was unconditionally discarding the first real image on every listing
- Every consumer (including docker-clean's untagged-image sweep) was silently missing the first image; on multi-host merges this corrupted host attribution too
- Fix: remove the `| tail -n +2` pipeline entirely — raw format output needs no stripping

Fixes ticket `brandon-docker-91h.2`.

## Test plan
- [ ] Run `docker images` locally and confirm the first image in `docker images` output now appears in `docker-clean` sweep candidates
- [ ] On a multi-host setup, verify no images are dropped from the listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)