### PR TITLE
shell-tools: fix proj2 CTRL-S git-status dead due to misspelled script name

### DIFF
--- a/shell-tools/.proj2z-load-status.sh
+++ b/shell-tools/.proj2z-load-status.sh
@@ -5,7 +5,7 @@
 query="$1"
 project_data_file="$2"
 script_dir="$3"
-git_status_script="${script_dir}/.proj2-git-status.sh"
+git_status_script="${script_dir}/.proj2z-git-status.sh"
 
 # Suppress job control
 setopt LOCAL_OPTIONS NO_NOTIFY NO_MONITOR


### PR DESCRIPTION
## Summary
- `.proj2z-load-status.sh` line 8 referenced `.proj2-git-status.sh` (missing the `z`); the real script is `.proj2z-git-status.sh`
- The `zsh "$git_status_script" ...` invocation on line 42 silently failed inside fzf's `reload` binding, leaving every status file empty
- One-character fix; verified the target script exists and is executable

## Test plan
- [ ] Open proj2z (`proj2z` command in shell)
- [ ] Press CTRL-S — list should reload with git status annotations on each project row
- [ ] Confirm rows show dirty/clean/ahead/behind status instead of blank status

Closes brandon-shell-tools-3lz.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)