### PR TITLE
shell-tools: fix proj2 CTRL-G open-in-GitHub via fzf --expect

### DIFF
--- a/shell-tools/proj2.zsh
+++ b/shell-tools/proj2.zsh
@@ -549,7 +549,10 @@ function proj2z {
   # Use fzf to select project(s) with multiple actions
   # CTRL-S loads git status for all projects
   # CTRL-P toggles preview pane
-  selected=$(fzf \
+  # --expect=ctrl-g: fzf prefixes output with the triggering key so action is
+  # determined from structured output, not side-channel temp files
+  local fzf_output
+  fzf_output=$(fzf \
     --multi \
     --ansi \
     --height=60% \
@@ -558,32 +561,27 @@ function proj2z {
     --query="$initial_query" \
     --header="CTRL-S=git status  CTRL-P=preview  CTRL-G=github" \
     --disabled \
+    --expect=ctrl-g \
     --bind "start:reload:$filter_cmd" \
     --bind "change:reload:$filter_cmd" \
     --bind "ctrl-s:reload:$status_loader_cmd" \
     --bind "ctrl-p:toggle-preview" \
-    --bind "ctrl-g:execute-silent(echo {+} > /tmp/proj2-github)+accept" \
     --preview="$preview_cmd" \
     --preview-window=right:50%:wrap \
     --select-1 \
     --exit-0)
 
-  if [[ -z $selected ]]; then
-    # Check for special actions
-    if [[ -f /tmp/proj2-github ]]; then
-      action="github"
-      selected=$(<"/tmp/proj2-github")
-      rm -f /tmp/proj2-github
-    elif [[ -f /tmp/proj2-print ]]; then
-      action="print"
-      selected=$(<"/tmp/proj2-print")
-      rm -f /tmp/proj2-print
-    else
-      # User cancelled
-      return 1
-    fi
-  else
+  local -a fzf_lines
+  fzf_lines=("${(@f)fzf_output}")
+  local key="${fzf_lines[1]}"
+  selected="${(j:\n:)fzf_lines[2,-1]}"
+
+  if [[ $key == "ctrl-g" && -n $selected ]]; then
+    action="github"
+  elif [[ -n $selected ]]; then
     action="cd"
+  else
+    return 1
   fi
 
   # Handle multi-select (split by newlines)
@@ -636,12 +634,6 @@ function proj2z {
       done
       ;;
 
-    print)
-      # Print paths
-      for item in "${selected_items[@]}"; do
-        echo "${project_paths[$item]}"
-      done
-      ;;
   esac
 }
 


### PR DESCRIPTION
## Summary
- CTRL-G was bound to `execute-silent(...)+accept`, which always populated `$selected` (non-empty), so the handler always took the `cd` branch — CTRL-G behaved identically to Enter and never opened GitHub
- The github branch was only reachable when `$selected` was empty (i.e., after a later ESC/cancel), at which point the stale `/tmp/proj2-github` file from the previous CTRL-G press would fire — opening GitHub for the *wrong* selection
- Fix: use `--expect=ctrl-g` so fzf prefixes output with the triggering key; action is determined from structured output, not world-shared `/tmp` side-channel files
- Removes the dead `/tmp/proj2-print` branch and unreachable `print)` action case

## Test plan
- [ ] Press CTRL-G in proj2z — verify `gh repo view --web` opens in browser for the highlighted project
- [ ] Press Enter in proj2z — verify normal cd/tmux-attach behavior unchanged
- [ ] Press ESC — verify cancellation returns to shell with no side effects
- [ ] Shell tests: `./shell-tools/tests/proj2/run_tests.sh` — all 6 shell tests pass

Closes brandon-shell-tools-3lz.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)