### PR TITLE
shell-tools: fix workspace-actions opt+w menu word-shredding and false success on tmux failure

### DIFF
--- a/shell-tools/workspace-actions.zsh
+++ b/shell-tools/workspace-actions.zsh
@@ -31,7 +31,7 @@ workspace-actions() {
   fi
 
   local context=$(_wa_detect_context)
-  local -a actions=($(_wa_get_actions_for_context "$context"))
+  local -a actions=("${(f)$(_wa_get_actions_for_context "$context")}")
 
   # Check if we have any actions
   if [[ ${#actions} -eq 0 ]]; then
@@ -187,7 +187,7 @@ _wa_get_actions_for_context() {
     fi
   done
 
-  echo "${matching_actions[@]}"
+  printf '%s\n' "${matching_actions[@]}"
 }
 
 # Execute selected action
@@ -260,8 +260,8 @@ _wa_tmux_sessions() {
         --reverse)
 
   if [[ -n "$session" ]]; then
-    tmux switch-client -t "$session" 2>/dev/null || \
-      echo "Switched to session: $session (use 'tmux attach -t $session' to attach)"
+    tmux switch-client -t "$session" || \
+      echo "Error: failed to switch to tmux session '$session'" >&2
   fi
 }
 


### PR DESCRIPTION
## Summary
- `_wa_get_actions_for_context`: replace `echo "${matching_actions[@]}"` (space-joins array) with `printf '%s\n' "${matching_actions[@]}"` — emits one entry per line, preserving multi-word action strings across the subshell boundary
- `workspace-actions`: consume result with `"${(f)$(...)}"`  to split exclusively on newlines instead of IFS (space/tab/newline), preventing word-shredding of entries like `'proj  Switch Project  Navigate to another project'`
- `_wa_tmux_sessions`: remove `2>/dev/null` (was silencing tmux errors) and fix the `||` branch to print an error message instead of the misleading success message it had before

## Test plan
- [ ] Source the plugin and press `opt+w` — menu should show full action rows (`proj  Switch Project  Navigate to another project`) not individual words
- [ ] Select an action — should execute correctly rather than `Error: unknown action`
- [ ] In a tmux session with an invalid target, the failure branch should now print `Error: failed to switch to tmux session '...'` to stderr

Closes brandon-shell-tools-3lz.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)