### PR TITLE
shell-tools: fix exec-find cd+run/cd+edit malformed commands

### DIFF
--- a/shell-tools/exec-find-zaw.zsh
+++ b/shell-tools/exec-find-zaw.zsh
@@ -14,7 +14,7 @@ bindkey '^[E' zaw-rad-exec-find
 ### action append to buffer: append file path to buffer
 function zaw-src-rad-exec-find() {
     local title="executable files"
-    : ${(A)candidates::=$(find . -perm -u=x -not -path "./.*/*" -type f)}
+    candidates=( ${(f)"$(find . -perm -u=x -not -path "./.*/*" -type f)"} )
     : ${(A)cand_descriptions::=$candidates}
 
     actions=(\
@@ -39,11 +39,13 @@ function zaw-rad-exec-find-run() {
 }
 
 function zaw-rad-exec-find-cd-run() {
-    zaw-rad-buffer-action "cd \"$(dirname \"$1\")\" && \"./$(basename \"$1\")\""
+    local dir=${(q)$(dirname "$1")} file=${(q)$(basename "$1")}
+    zaw-rad-buffer-action "cd ${dir} && ./${file}"
 }
 
 function zaw-rad-exec-find-cd-edit-file() {
-    zaw-rad-buffer-action "cd \"$(dirname \"$1\")\" && ${VISUAL:-${EDITOR:-vi}} \"$(basename \"$1\")\""
+    local dir=${(q)$(dirname "$1")} file=${(q)$(basename "$1")}
+    zaw-rad-buffer-action "cd ${dir} && ${VISUAL:-${EDITOR:-vi}} ${file}"
 }
 
 function zaw-rad-exec-find-cd-edit-repo() {


### PR DESCRIPTION
## Summary
- Fix `candidates` population using `${(f)"$(...)"}` to split on newlines only, preventing paths with spaces from being broken into multiple entries
- Fix `cd+run` and `cd+edit` actions: `\"` inside `$(...)` was passing literal quote chars to `dirname`/`basename`, producing garbage output for every input — replaced with `${(q)$(dirname "$1")}` pattern

## Test plan
- [ ] Source `exec-find-zaw.zsh` and trigger the zaw source (opt+shift+E)
- [ ] Verify executables under paths with spaces appear as single entries
- [ ] Select an entry with `cd + run` — confirm buffer shows `cd /correct/path && ./script` not garbage
- [ ] Select an entry with `cd + edit file` — confirm buffer shows valid editor command

Closes brandon-shell-tools-3lz.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)